### PR TITLE
overlay: Made reboot optional and fixed wait for reboot on local connection

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,5 @@ docker_filesystem_overlay_debs:
   - url: "http://kernel.ubuntu.com/~kernel-ppa/mainline/v3.19.8-vivid/linux-image-3.19.8-031908-generic_3.19.8-031908.201505110938_amd64.deb"
     checksum: "6e9a0731a94576a88213f7cb1f4c18172e547f5ef2f2d7a1794b7063bf3889c2"
 
+docker_filesystem_overlay_reboot: yes
+

--- a/tasks/overlay.yml
+++ b/tasks/overlay.yml
@@ -6,17 +6,20 @@
 - name: overlay - Install kernel package
   apt: deb=/tmp/{{ item.url | basename }} state=installed
   with_items: docker_filesystem_overlay_debs
+  register: kernel_updated
 
 - name: overlay - Reboot for new kernel
   command: shutdown -r now 'Ansible - Reboot for new kernel.'
+  when: docker_filesystem_overlay_reboot and kernel_updated | changed
 
 - name: overlay - Wait for reboot
   local_action:
     module: wait_for
-      host={{ ansible_ssh_host }}
-      port={{ ansible_ssh_port | default(22) }}
+      host={{ inventory_hostname }}
+      port={{ ansible_ssh_port | default(omit) }}
       delay=30
       timeout=600
       state=started
   become: no
+  when: docker_filesystem_overlay_reboot and kernel_updated | changed
 

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -1,3 +1,4 @@
 ---
 docker_filesystem: overlay
+docker_filesystem_overlay_reboot: no
 


### PR DESCRIPTION
Hello,

Well, it's what the PR's title says: optional reboot and fixed behaviour on local connection runs (useful for using the role with Packer, for instance).

Thank you!

Best regards,
